### PR TITLE
Ignore cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/playermarkers/cache/


### PR DESCRIPTION
This way, the web-accessible directory can be a symlink to the `playermarkers` directory instead of a copy.
