### PR TITLE
Set default size factor to 1.0 to fix blur

### DIFF
--- a/playermarkers/player.php
+++ b/playermarkers/player.php
@@ -2,7 +2,7 @@
 // original version was from TJ09
 // forum link: http://forums.bukkit.org/threads/info-mapmarkers-v0-3-4-1-1r6.843/
 
-$sizefactor = 1.5;
+$sizefactor = 1.0;
 $cachetime = 60*60*24; // 1 day
 
 function show_img($filename, $username="player") {

--- a/playermarkers/playermarkers.js
+++ b/playermarkers/playermarkers.js
@@ -20,7 +20,7 @@ var ANIMATED = true;
 
 var JSON_PATH = "/path/to/players.json";
 var IMG_PATH = "/path/to/player.php?username={username}";
-var IMG_SIZE_FACTOR = 1.5;
+var IMG_SIZE_FACTOR = 1.0;
 
 function PlayerMarker(ui, username, world, pos) {
 	this.ui = ui;


### PR DESCRIPTION
The player markers have a really annoying blur to them. This should fix that.
